### PR TITLE
feat: use client-side-only fetch polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "grunt-sass-lint": "^0.2.4",
     "grunt-tree": "^1.1.1",
     "id3-parser": "^2.0.0",
-    "isomorphic-fetch": "^2.2.1",
     "jest": "^24.5.0",
     "load-grunt-tasks": "^4.0.0",
     "markdown": "^0.5.0",
@@ -118,7 +117,8 @@
     "sass-lint": "^1.12.1",
     "shelljs": "^0.8.3",
     "standard": "^12.0.1",
-    "time-grunt": "^2.0.0"
+    "time-grunt": "^2.0.0",
+    "whatwg-fetch": "^3.0.0"
   },
   "scripts": {
     "watch": "grunt default",

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,5 +1,5 @@
 import '@babel/polyfill';
-import 'isomorphic-fetch';
+import 'whatwg-fetch';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router } from 'react-router-dom';


### PR DESCRIPTION
It's a bit suspicious that there haven't been any changes in the `package-lock.json`, but everything seems to work fine…